### PR TITLE
job:  #10296  Tweak integrity.arc to find a unique_id within a multi-…

### DIFF
--- a/model/mcooa/gen/integrity.arc
+++ b/model/mcooa/gen/integrity.arc
@@ -508,21 +508,25 @@ trace = "";
       .assign text = ""
       .select many o_ids related by o_obj->O_ID[R104]
       .for each o_id in o_ids
-        .select one o_oida related by o_id->O_OIDA[R105]
-        .if ( not_empty o_oida )
+        .select many o_oidas related by o_id->O_OIDA[R105]
+        .if ( not_empty o_oidas )
           .invoke r = instance_uniqueness( o_id )
           .assign text = text + r.body
           .// Find an identifying attribute to use to provide the user some way
           .// to locate the erroneous element.
-          .select one s_dt related by o_oida->O_ATTR[R105]->S_DT[R114] where ( selected.Name == "unique_id" )
-          .if ( not_empty s_dt )
-            .assign trace_attribute = o_oida.localAttributeName
-          .else
-            .select one s_dt related by o_oida->O_ATTR[R105]->O_RATTR[R106]->O_BATTR[R113]->O_ATTR[R106]->S_DT[R114] where ( selected.Name == "unique_id" )
+          .for each o_oida in o_oidas
+            .select one s_dt related by o_oida->O_ATTR[R105]->S_DT[R114] where ( selected.Name == "unique_id" )
             .if ( not_empty s_dt )
               .assign trace_attribute = o_oida.localAttributeName
+              .break for
+            .else
+              .select one s_dt related by o_oida->O_ATTR[R105]->O_RATTR[R106]->O_BATTR[R113]->O_ATTR[R106]->S_DT[R114] where ( selected.Name == "unique_id" )
+              .if ( not_empty s_dt )
+                .assign trace_attribute = o_oida.localAttributeName
+                .break for
+              .end if
             .end if
-          .end if
+          .end for
         .end if
       .end for
       .// If class has an attribute named "Name", use it for tracing purposes.

--- a/model/mcooa/gen/ooa.txt
+++ b/model/mcooa/gen/ooa.txt
@@ -839,6 +839,8 @@ for each s_dim in s_dims
     end if;
   end if;
   check_count = check_count + 1;
+  // formalizer participation R844:  Dimensions(S_DIM) -> Transient Var(V_TRN)
+  // formalizer participation R849:  Dimensions(S_DIM) -> Variable(V_VAR)
   // formalizer participation R120:  Dimensions(S_DIM) -> Attribute(O_ATTR)
   // checking conditional link only if referential attribute is non-null
   if ( not ( ::is_null_id( id:s_dim.Attr_ID ) and ::is_null_id( id:s_dim.Obj_ID ) ) )
@@ -1070,8 +1072,6 @@ for each s_dim in s_dims
   end if;
   check_count = check_count + 1;
   end if;
-  // formalizer participation R844:  Dimensions(S_DIM) -> Transient Var(V_TRN)
-  // formalizer participation R849:  Dimensions(S_DIM) -> Variable(V_VAR)
 end for;
 total_error_count = total_error_count + local_error_count;
 local_error_count = 0;
@@ -1336,7 +1336,7 @@ local_error_count = 0;
 select many o_ids from instances of O_ID;
 for each o_id in o_ids
   instance_count = instance_count + 1;
-  trace = "";
+  trace = ::check_trace( trace_attribute:"Obj_ID", trace_id:o_id.Obj_ID, name:"" );
   select many duplicate_o_ids from instances of O_ID where ( selected.Oid_ID == o_id.Oid_ID and selected.Obj_ID == o_id.Obj_ID );
   if ( cardinality duplicate_o_ids != 1 )
     ::check_log( message: "uniqueness violation in O_ID for identifier 1", trace:trace );
@@ -1557,7 +1557,7 @@ for each o_rattr in o_rattrs
       break;
     end if;
   else
-    if ( not ( o_ref.Attr_ID == o_rattr.Attr_ID and o_ref.Obj_ID == o_rattr.Obj_ID ) )
+    if ( not ( o_rattr.Attr_ID == o_ref.Attr_ID and o_rattr.Obj_ID == o_ref.Obj_ID ) )
       ::check_log( message: "referentials do not match identifiers between O_RATTR and O_REF", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2293,7 +2293,7 @@ for each r_simp in r_simps
       break;
     end if;
   else
-    if ( not ( r_part.Rel_ID == r_simp.Rel_ID ) )
+    if ( not ( r_simp.Rel_ID == r_part.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_SIMP and R_PART", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2449,7 +2449,7 @@ for each r_assoc in r_assocs
       break;
     end if;
   else
-    if ( not ( r_aone.Rel_ID == r_assoc.Rel_ID ) )
+    if ( not ( r_assoc.Rel_ID == r_aone.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_ASSOC and R_AONE", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2467,7 +2467,7 @@ for each r_assoc in r_assocs
       break;
     end if;
   else
-    if ( not ( r_aoth.Rel_ID == r_assoc.Rel_ID ) )
+    if ( not ( r_assoc.Rel_ID == r_aoth.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_ASSOC and R_AOTH", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2485,7 +2485,7 @@ for each r_assoc in r_assocs
       break;
     end if;
   else
-    if ( not ( r_assr.Rel_ID == r_assoc.Rel_ID ) )
+    if ( not ( r_assoc.Rel_ID == r_assr.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_ASSOC and R_ASSR", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2693,7 +2693,7 @@ for each r_subsup in r_subsups
       break;
     end if;
   else
-    if ( not ( r_super.Rel_ID == r_subsup.Rel_ID ) )
+    if ( not ( r_subsup.Rel_ID == r_super.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_SUBSUP and R_SUPER", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2849,7 +2849,7 @@ for each r_comp in r_comps
       break;
     end if;
   else
-    if ( not ( r_cone.Rel_ID == r_comp.Rel_ID ) )
+    if ( not ( r_comp.Rel_ID == r_cone.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_COMP and R_CONE", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -2867,7 +2867,7 @@ for each r_comp in r_comps
       break;
     end if;
   else
-    if ( not ( r_coth.Rel_ID == r_comp.Rel_ID ) )
+    if ( not ( r_comp.Rel_ID == r_coth.Rel_ID ) )
       ::check_log( message: "referentials do not match identifiers between R_COMP and R_COTH", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -3901,7 +3901,7 @@ for each sm_act in sm_acts
       break;
     end if;
   else
-    if ( not ( sm_ah.SM_ID == sm_act.SM_ID and sm_ah.Act_ID == sm_act.Act_ID ) )
+    if ( not ( sm_act.SM_ID == sm_ah.SM_ID and sm_act.Act_ID == sm_ah.Act_ID ) )
       ::check_log( message: "referentials do not match identifiers between SM_ACT and SM_AH", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -5004,7 +5004,7 @@ for each act_sel in act_sels
       break;
     end if;
   else
-    if ( not ( act_lnk.Statement_ID == act_sel.Statement_ID ) )
+    if ( not ( act_sel.Statement_ID == act_lnk.Statement_ID ) )
       ::check_log( message: "referentials do not match identifiers between ACT_SEL and ACT_LNK", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -8423,12 +8423,6 @@ for each v_par in v_pars
     end if;
   end if;
   check_count = check_count + 1;
-  // formalizer participation R669:  Actual Parameter(V_PAR) -> Function Invocation(ACT_FNC)
-  // formalizer participation R628:  Actual Parameter(V_PAR) -> Bridge Invocation(ACT_BRG)
-  // formalizer participation R627:  Actual Parameter(V_PAR) -> Operation Invocation(ACT_TFM)
-  // formalizer participation R679:  Actual Parameter(V_PAR) -> Interface Operation Invocation(ACT_IOP)
-  // formalizer participation R662:  Actual Parameter(V_PAR) -> Signal Invocation(ACT_SGN)
-  // formalizer participation R700:  Actual Parameter(V_PAR) -> Event Specification Statement(E_ESS)
   // formalizer participation R800:  Actual Parameter(V_PAR) -> Value(V_VAL)
   select one v_val related by v_par->V_VAL[R800];
   if ( empty v_val )
@@ -8472,6 +8466,12 @@ for each v_par in v_pars
   check_count = check_count + 1;
   end if;
   // formalizer participation R842:  Actual Parameter(V_PAR) -> Message Value(V_MSV)
+  // formalizer participation R669:  Actual Parameter(V_PAR) -> Function Invocation(ACT_FNC)
+  // formalizer participation R628:  Actual Parameter(V_PAR) -> Bridge Invocation(ACT_BRG)
+  // formalizer participation R627:  Actual Parameter(V_PAR) -> Operation Invocation(ACT_TFM)
+  // formalizer participation R679:  Actual Parameter(V_PAR) -> Interface Operation Invocation(ACT_IOP)
+  // formalizer participation R662:  Actual Parameter(V_PAR) -> Signal Invocation(ACT_SGN)
+  // formalizer participation R700:  Actual Parameter(V_PAR) -> Event Specification Statement(E_ESS)
 end for;
 total_error_count = total_error_count + local_error_count;
 local_error_count = 0;
@@ -13878,7 +13878,7 @@ for each i_exe in i_exes
       break;
     end if;
   else
-    if ( not ( i_stack.Execution_Engine_ID == i_exe.Execution_Engine_ID ) )
+    if ( not ( i_exe.Execution_Engine_ID == i_stack.Execution_Engine_ID ) )
       ::check_log( message: "referentials do not match identifiers between I_EXE and I_STACK", trace:trace );
       local_error_count = local_error_count + 1;
       if ( 10 < local_error_count )
@@ -16618,7 +16618,7 @@ local_error_count = 0;
 select many pe_srss from instances of PE_SRS;
 for each pe_srs in pe_srss
   instance_count = instance_count + 1;
-  trace = "";
+  trace = ::check_trace( trace_attribute:"Package_ID", trace_id:pe_srs.Package_ID, name:pe_srs.Name );
   select many duplicate_pe_srss from instances of PE_SRS where ( selected.Name == pe_srs.Name and selected.Type == pe_srs.Type and selected.Package_ID == pe_srs.Package_ID );
   if ( cardinality duplicate_pe_srss != 1 )
     ::check_log( message: "uniqueness violation in PE_SRS for identifier 1", trace:trace );
@@ -16652,7 +16652,7 @@ local_error_count = 0;
 select many pe_crss from instances of PE_CRS;
 for each pe_crs in pe_crss
   instance_count = instance_count + 1;
-  trace = "";
+  trace = ::check_trace( trace_attribute:"Id", trace_id:pe_crs.Id, name:pe_crs.Name );
   select many duplicate_pe_crss from instances of PE_CRS where ( selected.Name == pe_crs.Name and selected.Type == pe_crs.Type and selected.Id == pe_crs.Id );
   if ( cardinality duplicate_pe_crss != 1 )
     ::check_log( message: "uniqueness violation in PE_CRS for identifier 1", trace:trace );


### PR DESCRIPTION
…O_OIDA O_ID.  This results in three new trace_attributes to make life easier, even thought two of those trace_attributes are on classes that are not part of a persisted model (search results).  The few other changes are random ordering of comparisons and such.